### PR TITLE
Renames rethrow to match.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,16 +51,16 @@ const matcher = new PatternMatcher(error, { message: 'test' });
 const isMatch = matcher.match(); // true
 ```
 
-### `rethrow` Utility
+### `match` Utility
 
 TL;DR use when you want to match certain patterns within an error, and rethrow anything
 not matched.
 
 ```js
-import rethrow from 'exception-handling/utils/rethrow';
+import match from 'exception-handling/utils/match';
 
 getResource().catch(
-  rethrow({
+  match({
     matcher: { message: 'test' },
 
     onMatch(e) {

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,3 +1,3 @@
 export { default as PatternMatcher } from './utils/pattern-matcher';
-export { default as rethrow } from './utils/rethrow';
+export { default as match } from './utils/match';
 export { default as retry } from './utils/retry';

--- a/addon/utils/match.js
+++ b/addon/utils/match.js
@@ -5,11 +5,11 @@ import PatternMatcher from './pattern-matcher';
  * A utility function for catching / handling errors based upon
  * a particular pattern
  *
- * @name rethrow
+ * @name match
  * @param {Object} error The error object
- * @param {Object} rethrowHandler The rethrow handler
+ * @param {Object} matchHandler The match handler
  */
-function rethrow(error, { matcher, onMatch }) {
+function match(error, { matcher, onMatch }) {
   const patternMatcher =
     matcher instanceof PatternMatcher
       ? matcher
@@ -22,4 +22,4 @@ function rethrow(error, { matcher, onMatch }) {
   throw error;
 }
 
-export default curryRight(rethrow);
+export default curryRight(match);

--- a/addon/utils/pattern-matcher.js
+++ b/addon/utils/pattern-matcher.js
@@ -15,7 +15,7 @@ function getStrategy(error, handler) {
 
 /**
  * A simple pattern matcher - can be used on its own or in conjunction
- * with the retry utility / rethrow utility
+ * with the match utility / retry utility
  */
 export default class PatternMatcher {
   constructor(error, handler) {

--- a/tests/unit/match-test.js
+++ b/tests/unit/match-test.js
@@ -1,15 +1,15 @@
 import { module, test } from 'ember-qunit';
 import { reject } from 'rsvp';
-import { PatternMatcher, rethrow } from 'ember-exception-handling';
+import { PatternMatcher, match } from 'ember-exception-handling';
 
-module('Unit | Utility | exception-handling/utils/rethrow');
+module('Unit | Utility | exception-handling/utils/match');
 
 test('should not throw if the pattern matches', function(assert) {
   assert.expect(1);
 
   const error = new Error('test');
 
-  rethrow(error, {
+  match(error, {
     matcher: { message: 'test' },
     onMatch(e) {
       assert.equal(e, error, 'The error was handled properly');
@@ -23,17 +23,17 @@ test('should throw if the pattern does not match', function(assert) {
   const error = new Error('test');
 
   assert.throws(() => {
-    rethrow(error, { matcher: { message: 'bar' }, onMatch() {} });
+    match(error, { matcher: { message: 'bar' }, onMatch() {} });
   });
 });
 
-test('should not rethrow if the pattern matches when passed as an argument to catch', async function(assert) {
+test('should not match if the pattern matches when passed as an argument to catch', async function(assert) {
   assert.expect(2);
 
   const error = new Error('test');
 
   const ret = await reject(error).catch(
-    rethrow({
+    match({
       matcher(e) {
         return e && e.message === 'test';
       },
@@ -48,14 +48,14 @@ test('should not rethrow if the pattern matches when passed as an argument to ca
   assert.deepEqual(ret, [], 'The error is properly handled');
 });
 
-test('should rethrow if the pattern does not match when passed as an argument to catch', function(assert) {
+test('should match if the pattern does not match when passed as an argument to catch', function(assert) {
   assert.expect(1);
 
   const error = new Error('test');
 
   assert.rejects(
     reject(error).catch(
-      rethrow({
+      match({
         matcher: { message: 'bar' },
         onMatch() {},
       })
@@ -71,7 +71,7 @@ test('should accept an instance of PatternMatcher', function(assert) {
   const error = new Error('test');
 
   assert.throws(() => {
-    rethrow(error, {
+    match(error, {
       matcher: new PatternMatcher(error, { message: 'bar' }),
       onMatch() {},
     });
@@ -85,7 +85,7 @@ test('should accept an instance of PatternMatcher', function(assert) {
 
   assert.rejects(
     reject(error).catch(
-      rethrow({
+      match({
         matcher: new PatternMatcher(error, { message: 'bar' }),
         onMatch() {},
       })

--- a/tests/unit/match-test.js
+++ b/tests/unit/match-test.js
@@ -27,7 +27,7 @@ test('should throw if the pattern does not match', function(assert) {
   });
 });
 
-test('should not match if the pattern matches when passed as an argument to catch', async function(assert) {
+test('should not rethrow if the pattern matches when passed as an argument to catch', async function(assert) {
   assert.expect(2);
 
   const error = new Error('test');
@@ -48,7 +48,7 @@ test('should not match if the pattern matches when passed as an argument to catc
   assert.deepEqual(ret, [], 'The error is properly handled');
 });
 
-test('should match if the pattern does not match when passed as an argument to catch', function(assert) {
+test('should rethrow if the pattern does not match when passed as an argument to catch', function(assert) {
   assert.expect(1);
 
   const error = new Error('test');


### PR DESCRIPTION
The `rethrow` naming didn't adequately capture what the util was doing. Specifically, it didn't indicate what the happy path was, similar to what `retry` does. The happy path in the `rethrow` case is actually to _match_, not specifically to `rethrow`. In the case of both utilities, we have a happy path:

- `rethrow`'s happy path is to match, and rethrow _only_ if not matched
- `retry`'s happy path is to retry, and rethrow _only_ if not matched.

As such, it makes sense to rename `rethrow` to `match` so both APIs feel intuitive. Now, both have their happy paths, but will both rethrow if not matched.